### PR TITLE
feat: added a --json option that writes report to the json file

### DIFF
--- a/packages/cli/src/commands/index.tsx
+++ b/packages/cli/src/commands/index.tsx
@@ -3,13 +3,21 @@ import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
 import { z } from "zod";
 import AuditLicenses from "../components/audit-licenses/audit-licenses.js";
+import { JSON_RESULT_FILE_NAME } from "../constants/options-constants.js";
 import { useReadConfiguration } from "../hooks/use-read-config-file.js";
+import { useValidateJsonPath } from "../hooks/use-validate-json-path.js";
 
 export const options = z.object({
   verbose: z.boolean().default(false).describe("Verbose output"),
   filter: LicenseStatusSchema.optional().describe(
     "Filter by license status - whitelist, blacklist, or unknown",
   ),
+  json: z
+    .union([z.string(), z.boolean()])
+    .optional()
+    .describe(
+      `Save the result to a JSON file. If no path is not provided, a file named ${JSON_RESULT_FILE_NAME} will be created in the current directory.`,
+    ),
 });
 
 export type Options = {
@@ -18,15 +26,17 @@ export type Options = {
 
 export default function Index({ options }: Options) {
   const { configFile } = useReadConfiguration();
+  const validateJsonResult = useValidateJsonPath(options.json);
 
   // todo: handle errors thrown in readConfiguration - prompt the user accordingly
   // for now let's assume all is well and the file's been found
-  if (configFile?.config) {
+  if (configFile?.config && validateJsonResult.validated) {
     return (
       <AuditLicenses
         verbose={options.verbose}
         config={configFile.config}
         filter={options.filter}
+        json={validateJsonResult.path}
       />
     );
   }

--- a/packages/cli/src/components/audit-licenses/audit-licenses.tsx
+++ b/packages/cli/src/components/audit-licenses/audit-licenses.tsx
@@ -7,6 +7,7 @@ import type {
 import { Box, Text, useApp } from "ink";
 import { useEffect, useState } from "react";
 import { envSchema } from "../../env.js";
+import { saveResultToJson } from "../../utils/save-result-to-json.js";
 import { SpinnerWithLabel } from "../spinner-with-label.js";
 import AuditResult from "./audit-result.js";
 
@@ -14,12 +15,14 @@ export type AuditLicensesProps = {
   verbose: boolean;
   config: ConfigType;
   filter: LicenseStatus | undefined;
+  json: string | undefined;
 };
 
 export default function AuditLicenses({
   verbose,
   config,
   filter,
+  json,
 }: AuditLicensesProps) {
   const [working, setWorking] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -51,6 +54,12 @@ export default function AuditLicenses({
     };
     void getResults();
   }, [exit, config]);
+
+  useEffect(() => {
+    if (result && json) {
+      saveResultToJson(result, json);
+    }
+  }, [json, result]);
 
   if (error) {
     return (

--- a/packages/cli/src/constants/options-constants.ts
+++ b/packages/cli/src/constants/options-constants.ts
@@ -1,0 +1,1 @@
+export const JSON_RESULT_FILE_NAME = "license-auditor.results.json";

--- a/packages/cli/src/hooks/use-validate-json-path.ts
+++ b/packages/cli/src/hooks/use-validate-json-path.ts
@@ -6,7 +6,7 @@ import { JSON_RESULT_FILE_NAME } from "../constants/options-constants.js";
 
 export const useValidateJsonPath = (json: string | boolean | undefined) => {
   const [validated, setValidated] = useState(false);
-  const [jsonPath, setJsonPath] = useState<string | undefined>(undefined);
+  const [jsonPath, setJsonPath] = useState<string | undefined>();
 
   useEffect(() => {
     async function validatePath() {

--- a/packages/cli/src/hooks/use-validate-json-path.ts
+++ b/packages/cli/src/hooks/use-validate-json-path.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { useEffect, useState } from "react";
+import { JSON_RESULT_FILE_NAME } from "../constants/options-constants.js";
+
+export const useValidateJsonPath = (json: string | boolean | undefined) => {
+  const [validated, setValidated] = useState(false);
+  const [jsonPath, setJsonPath] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    async function validatePath() {
+      if (!json) {
+        setValidated(true);
+        return;
+      }
+      const jsonPath =
+        typeof json === "string"
+          ? json
+          : path.resolve(process.cwd(), JSON_RESULT_FILE_NAME);
+      const parentDirPath = path.dirname(jsonPath);
+
+      const statParentInfo = await statPath(parentDirPath);
+      if (!statParentInfo) {
+        throw new Error(`Path ${parentDirPath} does not exist`);
+      }
+
+      const statPathInfo = await statPath(jsonPath);
+
+      if (statPathInfo?.isDirectory()) {
+        console.warn(
+          `The provided path is a directory, a file with the name ${JSON_RESULT_FILE_NAME} will be created in the directory.`,
+        );
+        setJsonPath(path.join(jsonPath, JSON_RESULT_FILE_NAME));
+      } else {
+        setJsonPath(jsonPath);
+      }
+      setValidated(true);
+    }
+    void validatePath();
+  }, [json]);
+
+  return {
+    validated,
+    path: jsonPath,
+  };
+};
+
+export async function statPath(path: string) {
+  try {
+    return await fs.stat(path);
+  } catch (error) {
+    return null;
+  }
+}

--- a/packages/cli/src/utils/save-result-to-json.ts
+++ b/packages/cli/src/utils/save-result-to-json.ts
@@ -1,0 +1,18 @@
+import fs from "node:fs/promises";
+import type { LicenseAuditResult } from "@license-auditor/data";
+
+export async function saveResultToJson(
+  result: LicenseAuditResult,
+  jsonPath: string,
+) {
+  const parsedResult = {
+    ...result.groupedByStatus,
+    notFound: Array.from(result.notFound.entries()).map(
+      ([packageName, value]) => ({
+        packageName,
+        ...value,
+      }),
+    ),
+  };
+  await fs.writeFile(jsonPath, JSON.stringify(parsedResult, null, 2));
+}


### PR DESCRIPTION
When `--json` option has no value, the result will be saved to `license-auditor.results.json` file. 
If the provided path points to a directory, a `license-auditor.results.json` file with a report will be created in the specified directory