### PR TITLE
Made url in license object optional

### DIFF
--- a/packages/core/src/file-utils.test.ts
+++ b/packages/core/src/file-utils.test.ts
@@ -34,6 +34,11 @@ describe("packageJsonSchema", () => {
           .success,
       ).toBe(true);
     });
+    test("when licenses is a string", () => {
+      expect(
+        packageJsonSchema.safeParse({ name: "valid", licenses: "MIT" }).success,
+      ).toBe(true);
+    });
 
     test("when licenses are array of object", () => {
       expect(

--- a/packages/core/src/file-utils.test.ts
+++ b/packages/core/src/file-utils.test.ts
@@ -20,6 +20,14 @@ describe("packageJsonSchema", () => {
         }).success,
       ).toBe(true);
     });
+    test("when license is object and url is missing", () => {
+      expect(
+        packageJsonSchema.safeParse({
+          name: "valid",
+          license: { type: "MIT" },
+        }).success,
+      ).toBe(true);
+    });
     test("when licenses are array of string", () => {
       expect(
         packageJsonSchema.safeParse({ name: "valid", licenses: ["MIT"] })

--- a/packages/core/src/file-utils.ts
+++ b/packages/core/src/file-utils.ts
@@ -18,6 +18,7 @@ const licenseFieldSchema = z.union([z.string(), packageLicenseObjectSchema]);
 const licensesFieldSchema = z.union([
   z.array(z.string()),
   z.array(packageLicenseObjectSchema),
+  z.string(),
 ]);
 
 export const packageJsonSchema = z.union([

--- a/packages/core/src/file-utils.ts
+++ b/packages/core/src/file-utils.ts
@@ -9,7 +9,7 @@ type PackageJsonResult =
 const packageLicenseObjectSchema = z
   .object({
     type: z.string(),
-    url: z.string(),
+    url: z.string().optional(),
   })
   .transform((license) => license.type);
 


### PR DESCRIPTION
Some packages like qrcode-terminal don't have url in license object in package.json